### PR TITLE
V4-214  Highlight departure airports that are different than their ar…

### DIFF
--- a/controllers/air.cfc
+++ b/controllers/air.cfc
@@ -66,7 +66,8 @@
 
 		<cfset rc.User = variables.general.getUser(UserId = arguments.rc.Filter.getUserId())>
 		<cfset rc.Profile = variables.general.getUser(UserId = arguments.rc.Filter.getProfileId())>
-
+		<cfset rc.stItinerary = session.searches[SearchID].stItinerary>
+		
 		<cfreturn />
 	</cffunction>
 

--- a/views/air/default.cfm
+++ b/views/air/default.cfm
@@ -47,6 +47,7 @@
 					#View('air/filter2')#
 				</div>
 				<cfset variables.Fares = rc.trips.Fares>
+				<cfset variables.stItinerary = rc.stItinerary>
 				<cfset variables.BrandedFares = rc.trips.BrandedFares>
 				<!--- Needs to be in the variables scope to be passed into the view. --->
 				<cfset variables.trips = rc.trips>

--- a/views/air/list.cfm
+++ b/views/air/list.cfm
@@ -36,7 +36,6 @@
 										class="mdi mdi-cash-multiple flight-result-warning"></span>
 								</cfif>
 								<cfif structKeyExists(session.Filters[rc.SearchId].getUnusedTicketCarriers(), Segment.CarrierCode)>
-									<!--- Shane Pitts - Notification for unused tickets UI. --->
 									<span role="button" 
 										data-placement="right" 
 										data-toggle="tooltip" title="Unused tickets exist for this carrier."
@@ -100,7 +99,12 @@
 									</cfif>
 								</div>	
 								<div class="col-xs-6 col-lg-12 text-muted fs-1 p-xs-0 pl-xs-15">
-									#Segment.OriginAirportCode#-#Segment.DestinationAirportCode#
+									<cfif rc.Group NEQ 0 
+										AND stItinerary.Air[rc.Group-1].DestinationAirportCode NEQ Segment.OriginAirportCode>
+										<span style="color:red">#Segment.OriginAirportCode#</span>-#Segment.DestinationAirportCode#
+									<cfelse>
+										#Segment.OriginAirportCode#-#Segment.DestinationAirportCode#
+									</cfif>
 								</div>	
 							</div>
 						</div>


### PR DESCRIPTION
…rival airports.

Example, fly into ORD and we show options to return from MDW.  We want to make sure the traveler realizes that they are flying in and out of different airports.  I opened a ticket for Shane to clean up the UI by adding a tool tip, etc.