### PR TITLE
On initial load, bring unused ticket carriers to the top first

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -858,7 +858,7 @@ ul.tabs li a.active {
 	padding: 0;
 }
 
-.airline-col.iscontracted::after {
+.airline-col.ispreferred::after {
     content: '';
     position: absolute;
     top: 1px;
@@ -867,7 +867,7 @@ ul.tabs li a.active {
     border-style: solid;
 }
 
-.airline-col.iscontracted::after {
+.airline-col.ispreferred::after {
     border-width: 0.6em;
     border-left-color: #2e6da4;
     border-top-color: #2e6da4;

--- a/views/air/default.cfm
+++ b/views/air/default.cfm
@@ -171,7 +171,7 @@
 			$("#Email_Segment").val($("#fare"+Key).val());
 		}
 		
-		function sortTrips(dataelement) {
+		function sortTrips(dataelement, unusedAlwaysFirst) {
 			var divList = $('.trip');
 			var direction = 1;
 			var c = $('.listcontainer-header').find('[rel='+dataelement+']');
@@ -190,9 +190,21 @@
 				}
 			}
 
-			divList.sort(function(a, b){
-				return ($(a).data(dataelement)-$(b).data(dataelement)) * direction;
-			});
+			if (unusedAlwaysFirst){
+				divList.sort(function(a, b){
+					const aUnused = $(a).data('unusedticketmatch');
+					const bUnused = $(b).data('unusedticketmatch');
+					const aElement = $(a).data(dataelement);
+					const bElement = $(b).data(dataelement);
+					return aUnused === bUnused ? aElement - bElement : aUnused ? -1 : 1;
+				});
+			}
+			else {
+				divList.sort(function(a, b){
+					return ($(a).data(dataelement)-$(b).data(dataelement)) * direction;
+				});
+			}
+			
 			$("#listcontainer").html(divList);
 			postFilter();
 		}
@@ -790,9 +802,10 @@
 			});
 			$('#flight_number').val('').trigger('blur');
 			runFilters();
+			sortTrips('economy', true); // let's reset to our original view after resetting all filters
 		});
 
-		sortTrips('economy');
+		sortTrips('economy', true);
 		postFilter();
 
 		// hide modal window if user hits the back button

--- a/views/air/list.cfm
+++ b/views/air/list.cfm
@@ -12,7 +12,7 @@
 		data-connection="#Segment.Connections#"
 		data-airline="#Segment.CarrierCode#"
 		data-segmentid="#Segment.Segmentid#"
-		data-iscontracted="#structKeyExists(Segment, "IsPrivateFare") AND Segment.IsPrivateFare EQ 'true' ? 'true' : 'false'#"
+		data-ispreferred="#structKeyExists(Segment, "IsPreferred") AND Segment.IsPreferred EQ 'true' ? 'true' : 'false'#"
 		data-longsegment="#Segment.IsLongSegment#"
 		data-longandexpensivesegment="#Segment.IsLongAndExpensive#"
 		data-finditmatch="#Segment.IsFindItMatch#"
@@ -24,7 +24,7 @@
 	  	<div class="panel-body">
 			<div class="row flight-details-header">
 				<!---<span class="#ribbonclass#"></span>--->		
-				<div class="col-xs-2 col-lg-1 center airline-col #structKeyExists(Segment, "IsPrivateFare") AND Segment.IsPrivateFare EQ 'true'  ? 'iscontracted' : ''#">
+				<div class="col-xs-2 col-lg-1 center airline-col #structKeyExists(Segment, "IsPreferred") AND Segment.IsPreferred EQ 'true'  ? 'ispreferred' : ''#">
 					<div class="row">
 						<div class="col-xs-12">
 							<img class="carrierimg" src="assets/img/airlines/#Segment.CarrierCode#.png" title="#application.stAirVendors[Segment.CarrierCode].Name#" width="60">
@@ -170,13 +170,8 @@
 													<div class="cabin-class">
 														<div class="fs-1 cabin-description overflow-ellipse">
 															<cfif FareName NEQ ''>#FareName#<cfelse>#CabinClass EQ 'PremiumEconomy' ? 'Premium Economy' : CabinClass#</cfif>
-															<cfif Fare.IsPrivateFare>
-																<!--- <div role="button" 
-																class="contracted-after"
-																data-placement="right" 
-																title="Contracted"
-																data-toggle="tooltip"></div--->
-																<br>Contracted
+															<cfif Fare.PrivateFare>
+															<br>Contracted
 															</cfif>
 														</div>
 														<div class="fs-2 fare-display">


### PR DESCRIPTION
cross merge added additional files.. only real changes here are the sorting in default.cfm

When the SortTrips is called, it has an optional second argument that will test unusedticket matches first, then sort by the defined fare (default economy)

End result is, all trips should be initially sorted by carriers with unused tickets, then economy fare on initial load