### PR TITLE
#V4-207 moves the seatmap link to the details section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -979,12 +979,30 @@ ul.tabs li a.active {
 }
 
 .segment-details-extras ul {
-
+	list-style-type: none;
+	padding-left:0;
+	margin-left:0;
 }
 
 .segment-details-extras ul li {
 	font-size: 12px;
 	line-height: 14px;
+	padding-left:0;
+	margin-left:0;
+}
+
+.segment-details-extras ul li a.seatMapOpener {
+	cursor: pointer;
+    line-height: 24px;
+    display: block;
+    justify-content: center;
+    align-items: center;
+    display: flex;
+}
+
+.segment-details-extras ul li i {
+	font-size: 20px;
+    margin-right: 5px;
 }
 
 .segment-stopover {

--- a/views/air/list.cfm
+++ b/views/air/list.cfm
@@ -69,12 +69,6 @@
 							<div class="row">
 								<div class="col-xs-12 text-muted fs-1">
 									#Segment.FlightNumbers#
-									<cfif NOT Segment.FlightNumbers contains "WN" AND NOT Segment.FlightNumbers contains "F9">
-										<br>
-										<a class="seatMapOpener" data-toggle="modal" data-target="##seatMapModal" data-id='#serializeJson(Segment)#'>
-											Preview Seats
-										</a>
-									</cfif>
 								</div>
 							</div>
 							<div class="row">
@@ -312,6 +306,7 @@
 												<span>&nbsp;</span>
 												<span>(#Flight.DestinationAirportCode#)</span>
 											</div>
+											
 										</div>
 									</div>
 									<div class="segment-leg-operation-details fs-1">
@@ -340,15 +335,13 @@
 								#Segment.SegmentId# --->
 							</div>
 							<div class="segment-details-extras">
-								<!--- TODO Hide for now?
 								<ul>
-									<li><span></span> <span> Carry-on bags restricted </span>
-									</li>
-									<li> Average legroom (31 in)</li>
-									<li> Wi-Fi</li>
-									<li> In-seat power outlet</li>
-									<li> Stream media to your device</li>
-								</ul> --->
+									<cfif NOT Segment.FlightNumbers contains "WN" AND NOT Segment.FlightNumbers contains "F9"><li>
+										<a class="seatMapOpener" data-toggle="modal" data-target="##seatMapModal" data-id='#serializeJson(Segment)#'>
+											<i class="mdi mdi-seat-recline-normal" aria-hidden="true"></i> View Available Seats
+										</a>
+									</li></cfif>
+								</ul>
 							</div>
 						</div>
 						<cfset previousFlight = Flight>


### PR DESCRIPTION
Simply moves the link to the bottom and shows it beside the appropriate flight.

@gkernen I don't believe I could have broken anything, but the tab show/hide doesn't seem to trigger in the modal.  My hope was that I could modify the seatmap js to include an argument for what flight the link was clicked from, and toggle that pane after load, but it doesn't seem to want to ever show anything other than the first tab.  Might just need to create a bug ticket for that, if you can reproduce it.  maybe it's just me